### PR TITLE
Fix generate_questions and add tests

### DIFF
--- a/quiz_project/quiz_app/services.py
+++ b/quiz_project/quiz_app/services.py
@@ -32,23 +32,27 @@ def generate_questions(text):
 
     import unicodedata
 
-    base_key = 'historia'
-    key = base_key
-    index = 1
-
     def normalize_key(s):
         return ''.join(
             c for c in unicodedata.normalize('NFKD', s)
             if not unicodedata.combining(c)
         ).lower()
 
+    base_key = normalize_key(text)
+    key = base_key
+    index = 1
+
     while key_exists(cursor, normalize_key(key)):
         key = f"{base_key} {index}"
         index += 1
 
     value = questions
-    cursor.execute(f"INSERT INTO questions VALUES ({key}, {value})")
+    cursor.execute(
+        "INSERT INTO questions (key, value) VALUES (?, ?)",
+        (key, value)
+    )
     conn.commit()
+    conn.close()
 
     return questions
 

--- a/quiz_project/quiz_app/tests.py
+++ b/quiz_project/quiz_app/tests.py
@@ -1,3 +1,54 @@
 from django.test import TestCase
+from unittest.mock import patch
+from types import SimpleNamespace
+import tempfile
+import os
+import sqlite3 as py_sqlite3
 
-# Create your tests here.
+# Import the module after patching in setUp
+
+class GenerateQuestionsTests(TestCase):
+    def setUp(self):
+        # temporary database file
+        self.temp_db = tempfile.NamedTemporaryFile(delete=False)
+        self.db_path = self.temp_db.name
+        self.temp_db.close()
+
+        # Patch sqlite3.connect used in services module
+        real_connect = py_sqlite3.connect
+        patcher_db = patch('quiz_app.services.sqlite3.connect',
+                           side_effect=lambda *args, **kwargs: real_connect(self.db_path))
+        self.mock_connect = patcher_db.start()
+        self.addCleanup(patcher_db.stop)
+
+        # Patch OpenAI call to avoid network
+        patcher_ai = patch('quiz_app.services.client.chat.completions.create')
+        self.mock_ai = patcher_ai.start()
+        self.mock_ai.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='q1'))]
+        )
+        self.addCleanup(patcher_ai.stop)
+
+        # Import services after patches are in place
+        from quiz_app import services
+        self.services = services
+
+    def tearDown(self):
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_keys_unique_per_topic(self):
+        self.services.generate_questions('history')
+        self.services.generate_questions('history')
+        rows = self.services.print_all_questions()
+        keys = [row[1] for row in rows]
+        self.assertEqual(len(keys), len(set(keys)))
+
+    def test_insert_does_not_raise(self):
+        try:
+            self.services.generate_questions('geography')
+        except Exception as exc:
+            self.fail(f'generate_questions raised {exc}')
+        rows = self.services.print_all_questions()
+        self.assertEqual(len(rows), 1)
+


### PR DESCRIPTION
## Summary
- make `generate_questions` use the provided text as the key base
- use parameterized SQL insert and close connection
- add Django tests for question generation

## Testing
- `python manage.py test quiz_app`

------
https://chatgpt.com/codex/tasks/task_e_6866aaeb46348332be5d8cae7c76e795